### PR TITLE
로그인 API 분리

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,3 +364,8 @@
 ### 로그인 API 분리
 - [X] 새로운 모듈 생성
 - [X] 새로운 모듈로 기존의 login 기능 모두 이관
+- [X] JWT에 레스토랑 주인 여부 판단할 수 있는 정보 추가
+- [X] User 도메인 수정 (restaurantId 추가)
+- [X] createToken에 정보 추가
+
+* 파라미터를 전달하기 전 정합성 확인(isRestaurantOwner)을 통해 쓸모없는 데이터를 걸러낼 수 있음

--- a/httpTest/loginTest.http
+++ b/httpTest/loginTest.http
@@ -7,3 +7,13 @@ Content-Type: application/json
 }
 
 ###
+
+POST http://localhost:8080/session
+Content-Type: application/json
+
+{
+  "email": "ssajang@gmail.com",
+  "password": "password"
+}
+
+###

--- a/selfdemo-common/src/main/java/com/saul/springboot/selfDemo/domain/User.java
+++ b/selfdemo-common/src/main/java/com/saul/springboot/selfDemo/domain/User.java
@@ -34,6 +34,8 @@ public class User {
 
     private String password;
 
+    private Long restaurantId;
+
     public boolean isAdmin() {
 
         return level >= 100;
@@ -45,9 +47,20 @@ public class User {
         this.level = level;
     }
 
+    public void setRestaurantId(Long restaurantId) {
+
+        this.restaurantId = restaurantId;
+        this.level = 50;
+    }
+
     public boolean isActive() {
 
         return this.level > 0;
+    }
+
+    public boolean isRestaurantOwner() {
+
+        return this.level == 50;
     }
 
     public void deactivate() {

--- a/selfdemo-common/src/main/java/com/saul/springboot/selfDemo/utils/JwtUtil.java
+++ b/selfdemo-common/src/main/java/com/saul/springboot/selfDemo/utils/JwtUtil.java
@@ -1,6 +1,7 @@
 package com.saul.springboot.selfDemo.utils;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -16,11 +17,18 @@ public class JwtUtil {
         this.key = Keys.hmacShaKeyFor(secret.getBytes());
     }
 
-    public String createToken(Long userId, String userName) {
+    public String createToken(Long userId, String userName, Long restaurantId) {
 
-        String token = Jwts.builder()
+        JwtBuilder jwtBuilder = Jwts.builder()
                 .claim("userId", userId)
-                .claim("userName", userName)
+                .claim("userName", userName);
+
+        // restaurantId가 오는 경우만 만들어지도록
+        if (restaurantId != null) {
+            jwtBuilder.claim("restaurantId", restaurantId);
+        }
+
+        String token = jwtBuilder
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
 

--- a/selfdemo-common/src/test/java/com/saul/springboot/selfDemo/domain/UserTests.java
+++ b/selfdemo-common/src/test/java/com/saul/springboot/selfDemo/domain/UserTests.java
@@ -42,4 +42,21 @@ public class UserTests {
         assertThat(user.getAccessToken()).isEqualTo("");
 
     }
+
+    @Test
+    public void isRestaurantOwner() {
+
+        User mockUser = User.builder()
+                .email("poppo@gmail.com")
+                .name("poppo")
+                .level(1)
+                .build();
+
+        assertThat(mockUser.isRestaurantOwner()).isFalse();
+
+        mockUser.setRestaurantId(33L);
+
+        assertThat(mockUser.isRestaurantOwner()).isTrue();
+
+    }
 }

--- a/selfdemo-common/src/test/java/com/saul/springboot/selfDemo/utils/JwtUtilTest.java
+++ b/selfdemo-common/src/test/java/com/saul/springboot/selfDemo/utils/JwtUtilTest.java
@@ -24,7 +24,7 @@ public class JwtUtilTest {
         Long userId = 33L;
         String userName = "poppo";
 
-        String jwtToken = jwtUtil.createToken(userId, userName);
+        String jwtToken = jwtUtil.createToken(userId, userName, null);
 
         assertThat(jwtToken).contains(".");
     }

--- a/selfdemo-login-api/src/main/java/com/saul/springboot/selfDemo/interfaces/SessionController.java
+++ b/selfdemo-login-api/src/main/java/com/saul/springboot/selfDemo/interfaces/SessionController.java
@@ -26,18 +26,21 @@ public class SessionController {
             @RequestBody SessionRequestDto sessionRequestDto
     ) throws URISyntaxException {
 
-        User authenticated = userService.authenticate(
+        User authenticatedUser = userService.authenticate(
                 sessionRequestDto.getEmail(),
                 sessionRequestDto.getPassword());
 
         SessionResponseDto sessionResponseDto = SessionResponseDto.builder()
-                .accessToken(jwtUtil.createToken(authenticated.getId(), authenticated.getName()))
+                .accessToken(jwtUtil.createToken(
+                        authenticatedUser.getId(),
+                        authenticatedUser.getName(),
+                        authenticatedUser.isRestaurantOwner() ? authenticatedUser.getRestaurantId() : null
+                ))
                 .build();
 
         String url = "/session";
 
         return ResponseEntity.created(new URI(url)).body(sessionResponseDto);
-
     }
 
 }

--- a/selfdemo-login-api/src/test/java/com/saul/springboot/selfDemo/interfaces/SessionControllerTests.java
+++ b/selfdemo-login-api/src/test/java/com/saul/springboot/selfDemo/interfaces/SessionControllerTests.java
@@ -41,10 +41,10 @@ public class SessionControllerTests {
         String email = "poppo@gmail.com";
         String password = "password";
 
-        User mockUser = User.builder().id(id).name(name).build();
+        User mockUser = User.builder().id(id).name(name).level(1).build();
 
         given(userService.authenticate(eq(email), eq(password))).willReturn(mockUser);
-        given(jwtUtil.createToken(eq(id), eq(name))).willReturn("header.body.claim");
+        given(jwtUtil.createToken(id, name, null)).willReturn("header.body.claim");
 
         mvc.perform(post("/session")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -52,6 +52,38 @@ public class SessionControllerTests {
                          "    \"email\":\"poppo@gmail.com\",\n" +
                          "    \"password\":\"password\"\n" +
                          "}"))
+                .andExpect(status().isCreated())
+                .andExpect(header().stringValues("Location", "/session"))
+                .andExpect(content().string(containsString("\"accessToken\":")))
+                .andExpect(content().string(containsString(".")))
+        ;
+
+    }
+
+    @Test
+    public void tryLoginWithValidDataAndRestaurantOwner() throws Exception {
+
+        String name = "poppo";
+        Long id = 33L;
+        String email = "poppo@gmail.com";
+        String password = "password";
+
+        User mockUser = User.builder()
+                .id(id)
+                .name(name)
+                .level(50)
+                .restaurantId(3333L)
+                .build();
+
+        given(userService.authenticate(eq(email), eq(password))).willReturn(mockUser);
+        given(jwtUtil.createToken(id, name, 3333L)).willReturn("header.body.claim");
+
+        mvc.perform(post("/session")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\n" +
+                        "    \"email\":\"poppo@gmail.com\",\n" +
+                        "    \"password\":\"password\"\n" +
+                        "}"))
                 .andExpect(status().isCreated())
                 .andExpect(header().stringValues("Location", "/session"))
                 .andExpect(content().string(containsString("\"accessToken\":")))


### PR DESCRIPTION
- 기존 코드에서 로그인 기능만 따로 모듈로 분리
- 레스토랑 주인 여부 판단 및 JWT 토큰에 해당 정보 추가되도록 기능 구현

- 새로운 모듈 생성
- 새로운 모듈로 기존의 login 기능 모두 이관
- JWT에 레스토랑 주인 여부 판단할 수 있는 정보 추가
- User 도메인 수정 (restaurantId 추가)
- createToken에 정보 추가

* 파라미터를 전달하기 전 정합성 확인(isRestaurantOwner)을 통해 쓸모없는 데이터를 걸러낼 수 있음